### PR TITLE
fix engine.py, pyproject, and add qk_norm/embed_norm

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,6 +23,8 @@ n_layers: 12
 n_heads: 12
 rms_norm: True
 tie_embeddings: False
+qk_norm: True
+embed_norm: True
 torch_compile: True
 
 # note: step budget=token_budget/(seq_len * micro_batch_size * grad_accumulation_steps * ddp_world_size)

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1,13 +1,13 @@
-import torch
+from contextlib import nullcontext
 
+import torch
 from torch import distributed as dist
 from torch.nn import CrossEntropyLoss
 from torch.nn.parallel import DistributedDataParallel as DDP
-from contextlib import nullcontext
 
-from models import get_param_groups
-from optim import intialize_optimizer, initialize_scheduler
 from data.datasets.data_prep_utils import intra_doc_causal_mask
+from models import get_param_groups
+from optim import initialize_scheduler, intialize_optimizer
 
 
 def _move_to_device(batch, seq_len, device, intra_doc_masking):
@@ -172,6 +172,6 @@ class TorchEngine(torch.nn.Module):
       num_batches = num_batches_tensor.item()
 
     # calculate average loss
-    avg_loss = total_loss.item() / num_batches.item()
+    avg_loss = total_loss / num_batches
 
     return avg_loss

--- a/models/construct.py
+++ b/models/construct.py
@@ -1,4 +1,5 @@
 from fractions import Fraction
+
 import wandb
 
 
@@ -7,7 +8,7 @@ def construct_model(cfg):
 
   # Transformer++
   if cfg.model == 'transformer':
-    from .transformer import Transformer, ModelConfig
+    from .transformer import ModelConfig, Transformer
 
     model_cfg = ModelConfig(
       vocab_size=cfg.vocab_size,
@@ -19,6 +20,8 @@ def construct_model(cfg):
       mlp=cfg.mlp_class,
       seq_len=cfg.seq_len,
       tie_embeddings=cfg.tie_embeddings,
+      qk_norm=cfg.qk_norm,
+      embed_norm=cfg.embed_norm,
     )
     model = Transformer(model_cfg)
 

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -1,13 +1,14 @@
 """Transformer++, a simple LLama-style Transformer, supporting RMSNorm, RoPE, GLU"""
 
 import math
+from dataclasses import dataclass
+
 import torch
 import torch.nn.functional as F
 from torch import nn
-from dataclasses import dataclass
 
-from .components import RMSNorm, MLP, GLU, MLPReluSquared
-from .embeddings import precompute_freqs_cis, apply_rotary_emb_complex_like
+from .components import GLU, MLP, MLPReluSquared, RMSNorm
+from .embeddings import apply_rotary_emb_complex_like, precompute_freqs_cis
 
 
 @dataclass
@@ -35,6 +36,8 @@ class Attention(nn.Module):
 
     self.w_qkv = nn.Linear(cfg.dim, 3 * cfg.dim, bias=False)
     self.w_out = nn.Linear(cfg.dim, cfg.dim, bias=False)
+    self.q_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps)
+    self.k_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps)
 
   def forward(self, x, freqs_cis, attn_mask=None):
     bsz, seqlen, d = x.shape  # (bsz, seqlen, d)
@@ -44,6 +47,7 @@ class Attention(nn.Module):
     k = k.view(bsz, seqlen, self.n_heads, self.head_dim)  # (bsz, seqlen, nh, h_dim)
     v = v.view(bsz, seqlen, self.n_heads, self.head_dim)  # (bsz, seqlen, nh, h_dim)
 
+    q, k = self.q_norm(q), self.k_norm(k)
     q, k = apply_rotary_emb_complex_like(q, k, freqs_cis=freqs_cis)  # (bsz, seqlen, nh, h_dim)
 
     q = q.transpose(1, 2)  # (bsz, nh, seqlen, h_dim)
@@ -92,6 +96,7 @@ class Transformer(nn.Module):
       raise ValueError('dim must be divisible by n_heads')
 
     self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.dim)
+    self.embed_norm = RMSNorm(cfg.dim, cfg.rmsnorm_eps)
     self.layers = nn.ModuleList([Block(idx, cfg) for idx in range(cfg.n_layers)])
     self.out_norm = RMSNorm(cfg.dim, cfg.rmsnorm_eps)
     self.lm_head = nn.Linear(cfg.dim, cfg.vocab_size, bias=False)
@@ -108,6 +113,7 @@ class Transformer(nn.Module):
   def forward(self, x, attn_mask):
     # x: (bsz, seqlen)
     x = self.embed_tokens(x)  # (bsz, seqlen, dim)
+    x = self.embed_norm(x)
     self.freqs_cis = self.freqs_cis.to(x.device)
     for layer in self.layers:
       x = layer(x, self.freqs_cis, attn_mask)  # (bsz, seqlen, dim)

--- a/models/transformer.py
+++ b/models/transformer.py
@@ -22,6 +22,8 @@ class ModelConfig:
   mlp: str = 'mlp'
   rmsnorm_eps: float = 1e-6
   tie_embeddings: bool = False
+  qk_norm: bool = True
+  embed_norm: bool = True
 
 
 MLP_CLASSES = {'mlp': MLP, 'glu': GLU, 'mlp_relu_sq': MLPReluSquared}
@@ -36,8 +38,8 @@ class Attention(nn.Module):
 
     self.w_qkv = nn.Linear(cfg.dim, 3 * cfg.dim, bias=False)
     self.w_out = nn.Linear(cfg.dim, cfg.dim, bias=False)
-    self.q_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps)
-    self.k_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps)
+    self.q_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps) if cfg.qk_norm else nn.Identity()
+    self.k_norm = RMSNorm(self.head_dim, cfg.rmsnorm_eps) if cfg.qk_norm else nn.Identity()
 
   def forward(self, x, freqs_cis, attn_mask=None):
     bsz, seqlen, d = x.shape  # (bsz, seqlen, d)
@@ -96,7 +98,7 @@ class Transformer(nn.Module):
       raise ValueError('dim must be divisible by n_heads')
 
     self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.dim)
-    self.embed_norm = RMSNorm(cfg.dim, cfg.rmsnorm_eps)
+    self.embed_norm = RMSNorm(cfg.dim, cfg.rmsnorm_eps) if cfg.embed_norm else nn.Identity()
     self.layers = nn.ModuleList([Block(idx, cfg) for idx in range(cfg.n_layers)])
     self.out_norm = RMSNorm(cfg.dim, cfg.rmsnorm_eps)
     self.lm_head = nn.Linear(cfg.dim, cfg.vocab_size, bias=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 license = { file = "LICENSE" }
 readme = "README.md"
 version = "0.1.0"
-requires-python = ">=3.12"
+requires-python = "==3.12.0"
 dependencies = [
     "absl-py>=2.1.0",
     "numpy>=2.3.4",
@@ -15,7 +15,8 @@ dependencies = [
     "schedulefree>=1.4.1",
     "torch>=2.6.0",
     "transformers>=4.44.2",
-    "wandb>=0.22.2"
+    "wandb>=0.22.2",
+    "datasets>=4.7.0"
 ]
 
 [build-system]


### PR DESCRIPTION
engine.py
- fix bug where the code called .item() on float

pyproject
- fix bug with python 3.14 serialization problem. the solution is to pin python to 3.12.0
- add missing dependencies: datasets.

features
- add qk_norm
- add embed_norm